### PR TITLE
Filled out eLevelId enum

### DIFF
--- a/OpenDiablo2.Common/Enums/eLevelId.cs
+++ b/OpenDiablo2.Common/Enums/eLevelId.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using OpenDiablo2.Common.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,8 +10,58 @@ namespace OpenDiablo2.Common.Enums
     public enum eLevelId
     {
         None,
-        Act1_Town = 1,
+        Act1_Town1 = 1,
+        Act1_CaveTreasure2 = 13,
+        Act1_CaveTreasure3 = 14,
+        Act1_CaveTreasure4 = 15,
+        Act1_CaveTreasure5 = 16,
+        Act1_CryptCountessX = 25,
+        Act1_Tower2 = 20,
+        Act1_MonFront = 26,
+        Act1_Courtyard1 = 27,
+        Act1_Courtyard2 = 32,
+        Act1_Cathedral = 33,
+        Act1_Andariel = 37,
+        Act1_Tristram = 38,
+        Act2_Town = 40,
+        Act2_Harem = 50,
+        Act2_DurielsLair = 73,
+        Act3_Town = 75,
+        Act3_DungeonTreasure1 = 90,
+        Act3_DungeonTreasure2 = 91,
+        Act3_SewerTreasureX = 93,
+        Act3_Temple1 = 94,
+        Act3_Temple2 = 95,
+        Act3_Temple3 = 96,
+        Act3_Temple4 = 97,
+        Act3_Temple5 = 98,
+        Act3_Temple6 = 99,
+        Act3_MephistoComplex = 102,
         Act4_Fortress = 103,
-        Act5_Baal_Entrance = 120
+        Act5_Town = 109,
+        Act5_TempleFinalRoom = 124,
+        Act5_ThroneRoom = 131,
+        Act5_WorldStone = 132,
+        Act5_TempleEntrance = 121,
+        Act5_BaalEntrance = 120,
+    }
+
+    public class ELevelIdHelper
+    {
+        public static string GenerateEnum(List<LevelPreset> levelPresets)
+        {
+            string output = string.Empty;
+            foreach (LevelPreset lp in levelPresets)
+            {
+                // need to convert e.g. 'Act 1 - Town 1' to 'Act1_Town'
+                if (lp.LevelId == 0)
+                {
+                    continue;
+                }
+                string name = lp.Name.Replace(" - ", "_").Replace(" ", "").Replace("'", "");
+                output += name + " = " + lp.LevelId + ",\r\n";
+            }
+            return output;
+        }
     }
 }

--- a/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
+++ b/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
+++ b/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenDiablo2.Common\OpenDiablo2.Common.csproj" />
+    <ProjectReference Include="..\OpenDiablo2.Core\OpenDiablo2.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
+++ b/OpenDiablo2.Core.UT/OpenDiablo2.Core.UT.csproj
@@ -1,20 +1,77 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OpenDiablo2.Core.UT</RootNamespace>
+    <AssemblyName>OpenDiablo2.Core.UT</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\OpenDiablo2.Common\OpenDiablo2.Common.csproj" />
-    <ProjectReference Include="..\OpenDiablo2.Core\OpenDiablo2.Core.csproj" />
+    <Compile Include="UT_EngineDataManager.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenDiablo2.Common\OpenDiablo2.Common.csproj">
+      <Project>{b743160e-a0bb-45dc-9998-967a85e50562}</Project>
+      <Name>OpenDiablo2.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenDiablo2.Core\OpenDiablo2.Core.csproj">
+      <Project>{8fc6bf7d-835a-47c1-a6b2-125495fa0900}</Project>
+      <Name>OpenDiablo2.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/OpenDiablo2.Core.UT/Properties/AssemblyInfo.cs
+++ b/OpenDiablo2.Core.UT/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("OpenDiablo2.Core.UT")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OpenDiablo2.Core.UT")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("f187face-cba2-4012-8308-06ccdc9d6ab1")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
+++ b/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenDiablo2.Common.Enums;
 using OpenDiablo2.Common.Models;
 using System.IO;

--- a/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
+++ b/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
@@ -33,15 +33,5 @@ namespace OpenDiablo2.Core.UT
             Assert.IsTrue(edm.LevelPresets.Count > 0);
             Assert.IsTrue(edm.LevelTypes.Count > 0);
         }
-
-        [TestMethod]
-        public void GenerateELevelIdTest()
-        {
-            EngineDataManager edm = LoadData();
-
-            string output = ELevelIdHelper.GenerateEnum(edm.LevelPresets);
-
-            Assert.IsTrue(output.Length > 0);
-        }
     }
 }

--- a/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
+++ b/OpenDiablo2.Core.UT/UT_EngineDataManager.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenDiablo2.Common.Enums;
+using OpenDiablo2.Common.Models;
+using System.IO;
+
+namespace OpenDiablo2.Core.UT
+{
+    [TestClass]
+    public class UT_EngineDataManager
+    {
+        private static readonly string DataPath = @"C:\PutYourMPQsHere\";
+
+        private EngineDataManager LoadData()
+        {
+            GlobalConfiguration globalconfig = new GlobalConfiguration
+            {
+                BaseDataPath = Path.GetFullPath(DataPath)
+            };
+
+            MPQProvider mpqprov = new MPQProvider(globalconfig);
+
+            EngineDataManager edm = new EngineDataManager(mpqprov);
+
+            return edm;
+        }
+
+        [TestMethod]
+        public void DataLoadTest()
+        {
+            EngineDataManager edm = LoadData();
+
+            Assert.IsTrue(edm.LevelDetails.Count > 0);
+            Assert.IsTrue(edm.LevelPresets.Count > 0);
+            Assert.IsTrue(edm.LevelTypes.Count > 0);
+        }
+
+        [TestMethod]
+        public void GenerateELevelIdTest()
+        {
+            EngineDataManager edm = LoadData();
+
+            string output = ELevelIdHelper.GenerateEnum(edm.LevelPresets);
+
+            Assert.IsTrue(output.Length > 0);
+        }
+    }
+}

--- a/OpenDiablo2.Core.UT/packages.config
+++ b/OpenDiablo2.Core.UT/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+</packages>

--- a/OpenDiablo2.Core/GameState/GameState.cs
+++ b/OpenDiablo2.Core/GameState/GameState.cs
@@ -41,7 +41,7 @@ namespace OpenDiablo2.Core.GameState_
         public void Initialize(string characterName, eHero hero)
         {
             sceneManager.ChangeScene("Game");
-            ChangeMap(eLevelId.Act1_Town);
+            ChangeMap(eLevelId.Act1_Town1);
         }
 
         public void ChangeMap(eLevelId levelId)

--- a/OpenDiablo2.TestConsole/App.config
+++ b/OpenDiablo2.TestConsole/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/OpenDiablo2.TestConsole/OpenDiablo2.TestConsole.csproj
+++ b/OpenDiablo2.TestConsole/OpenDiablo2.TestConsole.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{40BD2DDE-DC6F-4F6D-9050-9B423C631192}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>OpenDiablo2.TestConsole</RootNamespace>
+    <AssemblyName>OpenDiablo2.TestConsole</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenDiablo2.Common\OpenDiablo2.Common.csproj">
+      <Project>{b743160e-a0bb-45dc-9998-967a85e50562}</Project>
+      <Name>OpenDiablo2.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenDiablo2.Core\OpenDiablo2.Core.csproj">
+      <Project>{8fc6bf7d-835a-47c1-a6b2-125495fa0900}</Project>
+      <Name>OpenDiablo2.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/OpenDiablo2.TestConsole/Program.cs
+++ b/OpenDiablo2.TestConsole/Program.cs
@@ -1,0 +1,164 @@
+﻿using OpenDiablo2.Common.Enums;
+using OpenDiablo2.Common.Models;
+using OpenDiablo2.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenDiablo2.TestConsole
+{
+    class Program
+    {
+        private static GlobalConfiguration GlobalConfig = null;
+        private static MPQProvider MPQProv = null;
+        private static EngineDataManager EngineDataMan = null;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("OpenDiablo2 TestConsole Loaded");
+            Console.WriteLine("Type 'help' for more info, 'exit' to close.");
+            bool exit = false;
+            while (!exit)
+            {
+                Console.Write("> ");
+                string command = Console.ReadLine();
+                List<string> words = GetWords(command);//new List<string>(command.Split(' '));
+                string func = words[0].ToUpper();
+                words.RemoveAt(0);
+
+                switch (func)
+                {
+                    case "HELP":
+                        Help(words);
+                        break;
+                    case "EXIT":
+                        exit = true;
+                        break;
+                    case "LOADDATA":
+                        LoadData(words);
+                        break;
+                    case "WRITELEVELIDS":
+                        WriteELevelIds(words);
+                        break;
+                }
+            }
+            // close out the program after exiting
+            Environment.Exit(0);
+        }
+
+
+        public static List<string> GetWords(string msg)
+        {
+            List<string> outs = new List<string>();
+
+            string curword = "";
+            bool inquote = false;
+            int i = 0;
+            while (i < msg.Length)
+            {
+                char c = msg[i];
+                if (c == '"')
+                {
+                    inquote = !inquote;
+                }
+                else if (c == ' ' && !inquote)
+                {
+                    outs.Add(curword);
+                    curword = "";
+                }
+                else
+                {
+                    curword += c;
+                }
+                i++;
+            }
+            outs.Add(curword);
+
+            return outs;
+        }
+
+        public static void Help(List<string> words)
+        {
+            if(words.Count < 1)
+            {
+                Console.WriteLine("Commands: HELP, EXIT, LOADDATA, WRITELEVELIDS");
+                Console.WriteLine("Type 'HELP [command]' for more info.");
+                return;
+            }
+
+            string command = words[0].ToUpper();
+            switch (command)
+            {
+                case "LOADDATA":
+                    Console.WriteLine("'LOADDATA [path to mpq folder]' will load the MPQs and parse their data.");
+                    Console.WriteLine("This function is pre-requisite to many others.");
+                    return;
+                case "WRITELEVELIDS":
+                    Console.WriteLine("'WRITELEVELIDS [filepath to write to]' will write the level ids enum to a file.");
+                    Console.WriteLine("This function requires the data to be loaded first.");
+                    return;
+            }
+
+            // if we get to the end, no command was matched
+            Help(new List<string>()); // run with an empty list to trigger default message
+        }
+
+        public static void LoadData(List<string> words)
+        {
+            if (words.Count < 1)
+            {
+                Console.WriteLine("Must supply a path to the folder where the MPQs are stored.");
+                return;
+            }
+            string path = words[0];
+
+            if (EngineDataMan != null)
+            {
+                Console.WriteLine("Data already loaded!");
+                return;
+            }
+
+            try
+            {
+                GlobalConfig = new GlobalConfiguration
+                {
+                    BaseDataPath = Path.GetFullPath(path)
+                };
+
+                MPQProv = new MPQProvider(GlobalConfig);
+
+                EngineDataMan = new EngineDataManager(MPQProv);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("Failed to load data! " + e.Message);
+                return;
+            }
+
+            Console.WriteLine("Data loaded.");
+        }
+
+        public static void WriteELevelIds(List<string> words)
+        {
+            if (words.Count < 1)
+            {
+                Console.WriteLine("Must supply a filepath to write to.");
+                return;
+            }
+            if(EngineDataMan == null)
+            {
+                Console.WriteLine("You must load the MPQ data first! See 'HELP LOADDATA'.");
+                return;
+            }
+            string path = words[0];
+            string output = "public enum eLevelId\r\n{\r\nNone,\r\n";
+            output += ELevelIdHelper.GenerateEnum(EngineDataMan.LevelPresets);
+            output += "}";
+            File.WriteAllText(path, output);
+            Console.WriteLine("Wrote eLevelIds enum to " + path + ".");
+        }
+    }
+}

--- a/OpenDiablo2.TestConsole/Properties/AssemblyInfo.cs
+++ b/OpenDiablo2.TestConsole/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OpenDiablo2.TestConsole")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OpenDiablo2.TestConsole")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("40bd2dde-dc6f-4f6d-9050-9b423c631192")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OpenDiablo2.sln
+++ b/OpenDiablo2.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.28306.52
+VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2", "OpenDiablo2\OpenDiablo2.csproj", "{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}"
 EndProject
@@ -13,32 +13,62 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.SDL2", "OpenDia
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Scenes", "OpenDiablo2.Scenes\OpenDiablo2.Scenes.csproj", "{05224FE7-293F-4184-B1D6-89F5171B60E0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Core.UT", "OpenDiablo2.Core.UT\OpenDiablo2.Core.UT.csproj", "{9E33ABEB-B81D-4A53-886B-00D069E50370}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Debug|x64.ActiveCfg = Debug|x64
 		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Debug|x64.Build.0 = Debug|x64
+		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Release|x64.ActiveCfg = Release|x64
 		{2B0CF1AC-06DD-4322-AE8B-FF8A8C70A3CD}.Release|x64.Build.0 = Release|x64
+		{B743160E-A0BB-45DC-9998-967A85E50562}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B743160E-A0BB-45DC-9998-967A85E50562}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B743160E-A0BB-45DC-9998-967A85E50562}.Debug|x64.ActiveCfg = Debug|x64
 		{B743160E-A0BB-45DC-9998-967A85E50562}.Debug|x64.Build.0 = Debug|x64
+		{B743160E-A0BB-45DC-9998-967A85E50562}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B743160E-A0BB-45DC-9998-967A85E50562}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B743160E-A0BB-45DC-9998-967A85E50562}.Release|x64.ActiveCfg = Release|x64
 		{B743160E-A0BB-45DC-9998-967A85E50562}.Release|x64.Build.0 = Release|x64
+		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Debug|x64.ActiveCfg = Debug|x64
 		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Debug|x64.Build.0 = Debug|x64
+		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Release|x64.ActiveCfg = Release|x64
 		{8FC6BF7D-835A-47C1-A6B2-125495FA0900}.Release|x64.Build.0 = Release|x64
+		{1F8731D5-393B-4561-9CEA-887A2F466576}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F8731D5-393B-4561-9CEA-887A2F466576}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F8731D5-393B-4561-9CEA-887A2F466576}.Debug|x64.ActiveCfg = Debug|x64
 		{1F8731D5-393B-4561-9CEA-887A2F466576}.Debug|x64.Build.0 = Debug|x64
+		{1F8731D5-393B-4561-9CEA-887A2F466576}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F8731D5-393B-4561-9CEA-887A2F466576}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1F8731D5-393B-4561-9CEA-887A2F466576}.Release|x64.ActiveCfg = Release|x64
 		{1F8731D5-393B-4561-9CEA-887A2F466576}.Release|x64.Build.0 = Release|x64
+		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Debug|x64.ActiveCfg = Debug|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Debug|x64.Build.0 = Debug|x64
+		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|Any CPU.ActiveCfg = Release|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|x64.ActiveCfg = Release|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|x64.Build.0 = Release|x64
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenDiablo2.sln
+++ b/OpenDiablo2.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Scenes", "OpenD
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Core.UT", "OpenDiablo2.Core.UT\OpenDiablo2.Core.UT.csproj", "{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.TestConsole", "OpenDiablo2.TestConsole\OpenDiablo2.TestConsole.csproj", "{40BD2DDE-DC6F-4F6D-9050-9B423C631192}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,14 @@ Global
 		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|x64.ActiveCfg = Release|Any CPU
 		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|x64.Build.0 = Release|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Debug|x64.Build.0 = Debug|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Release|x64.ActiveCfg = Release|Any CPU
+		{40BD2DDE-DC6F-4F6D-9050-9B423C631192}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenDiablo2.sln
+++ b/OpenDiablo2.sln
@@ -13,7 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.SDL2", "OpenDia
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Scenes", "OpenDiablo2.Scenes\OpenDiablo2.Scenes.csproj", "{05224FE7-293F-4184-B1D6-89F5171B60E0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Core.UT", "OpenDiablo2.Core.UT\OpenDiablo2.Core.UT.csproj", "{9E33ABEB-B81D-4A53-886B-00D069E50370}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenDiablo2.Core.UT", "OpenDiablo2.Core.UT\OpenDiablo2.Core.UT.csproj", "{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,14 +61,14 @@ Global
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|Any CPU.ActiveCfg = Release|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|x64.ActiveCfg = Release|x64
 		{05224FE7-293F-4184-B1D6-89F5171B60E0}.Release|x64.Build.0 = Release|x64
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Debug|x64.Build.0 = Debug|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|x64.ActiveCfg = Release|Any CPU
-		{9E33ABEB-B81D-4A53-886B-00D069E50370}.Release|x64.Build.0 = Release|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Debug|x64.Build.0 = Debug|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|x64.ActiveCfg = Release|Any CPU
+		{F187FACE-CBA2-4012-8308-06CCDC9D6AB1}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Added ELevelIdHelper class which contains code that generates the eLevelId enum from the mpq data
- Renamed some enum values for consistency (e.g. Act1_Town -> Act1_Town1, as it is in the mpq)

Because this enum is hard coded, this function generates the code that should be placed within; it's not a runtime generation. Depending on what we want to support in the future / what this enum is used for (e.g. if we wanted to support mods with custom level ids), we may want to consider using a different structure such as a dictionary that can be generated at runtime. For the moment, however, this seems fine.

Also, I renamed some of the enum values (Act1_Town -> Act1_Town1 and Act5_Baal_Entrance -> Act5_BaalEntrance) to be consistent with the auto-generation.

- Added OpenDiablo2.Core.UT unit test project
- Added a unit test that verifies EngineDataManager works

Format I'm used to for unit testing is to give each project a corresponding .UT project. If you'd prefer something else, I don't have strong feelings about it. I added a unit test for the EngineDataManager that tests loading the MPQ files. Currently, though, it requires you to put them in a specific place or to modify a parameter in the unit test code in order to locate your MPQ files. I've been trying to think of a nicer solution to this but haven't come up with anything yet (if we had code that tried to auto-locate the mpqs on the user's disk, that might be an option).

- Added a unit test that runs the ELevelIdHelper generate function

It's probably kind of messy to have the hook for this helper function be in a unit test, but it also doesn't make sense to call it anywhere in runtime as the enum can't be dynamically generated. Currently what I'm doing is debugging into the unit test and copy/pasting the result into the eLevelId code. Seeing as the default mpqs aren't going to change on us, this probably never needs to be run again.