### PR TITLE
Fix issue with typing char name with no hero selected

### DIFF
--- a/OpenDiablo2.Scenes/SelectHeroClass.cs
+++ b/OpenDiablo2.Scenes/SelectHeroClass.cs
@@ -339,7 +339,7 @@ namespace OpenDiablo2.Scenes
                 return;
             }
 
-            if (characterNameTextBox.Text.Length >= 15)
+            if (characterNameTextBox.Text.Length >= 15 || !selectedHero.HasValue)
                 return;
 
             if (!"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".Contains(charcode))


### PR DESCRIPTION
Fixes https://github.com/essial/OpenDiablo2/issues/22

Although  I couldn't get the issue to reproduce from the start screen, only when I had already hit "new game" and had yet to select a character